### PR TITLE
Set min_overlap = 0L in bed_intersect() calls for valr 0.10.0 compatibility

### DIFF
--- a/R/preprocessing-blacklisthighmap-utils.R
+++ b/R/preprocessing-blacklisthighmap-utils.R
@@ -205,7 +205,7 @@ retrievechrom <- function(genomename, verbose, filterchrom = TRUE) {
         ## Retrieving scores on annotations of strand
         if (verbose) message("\t\t Retrieving scores on annotations of strand") # nolint
         suppressWarnings(annoscores <- valr::bed_intersect(valtib,
-            allwindstrand, suffix = c("", ".window")))
+            allwindstrand, min_overlap = 0L, suffix = c("", ".window")))
 
         rm(valtib, allwindchromtib, allwindstrand)
         if (showmemory) print(gc()) else invisible(gc())

--- a/R/preprocessing-blacklisthighmap.R
+++ b/R/preprocessing-blacklisthighmap.R
@@ -31,7 +31,8 @@
     maptracktib) {
 
         ## Set scores overlapping black list to NA
-        resblack <- valr::bed_intersect(currenttrans, blacklisttib)
+        resblack <- valr::bed_intersect(currenttrans, blacklisttib,
+            min_overlap = 0L)
         if (!isTRUE(all.equal(nrow(resblack), 0))) {
             strtransvec <- paste(currenttrans$chrom, currenttrans$start,
                 currenttrans$end, sep = "-")
@@ -48,7 +49,8 @@
         ## low mappability intervals)
         currenttrans$chrom <- as.character(currenttrans$chrom)
         maptracktib$chrom <- as.character(maptracktib$chrom)
-        resmap <- valr::bed_intersect(currenttrans, maptracktib)
+        resmap <- valr::bed_intersect(currenttrans, maptracktib,
+            min_overlap = 0L)
         if (!isTRUE(all.equal(nrow(resmap), 0))) {
             ## Compute strtransvec only if no overlap with black list was found
             if (isTRUE(all.equal(nrow(resblack), 0)))


### PR DESCRIPTION
## Summary

valr 0.10.0 (currently being submitted to CRAN) changes the default `min_overlap` of `valr::bed_intersect()` from `0` to `1L`, completing a deprecation begun in valr 0.8.0. This surfaced in the reverse-dependency check as two failing tepr tests (`test-preprocessing.R:26` and `test-preprocessing-createtablescores.R:40`), with small numeric drift in the `score.x` / `score.y` columns.

## Cause

With `min_overlap = 1L`, **book-ended** intervals — ones that touch at a boundary but share zero bases under valr's half-open coordinates, e.g. `[0,10)` and `[10,20)` — are no longer treated as overlapping (matching bedtools). tepr's `.retrieveannoscores()` intersects contiguously-tiled bedGraph intervals against window annotations, so `bedgraph.end == window.start` happens constantly. Those book-ended pairs used to contribute their score to the adjacent window and now drop out, shifting per-window scores slightly.

## Fix

Pass `min_overlap = 0L` explicitly to the three `valr::bed_intersect()` calls, restoring the previous behavior exactly:

- `R/preprocessing-blacklisthighmap-utils.R` — `.retrieveannoscores()`
- `R/preprocessing-blacklisthighmap.R` — `.removeblackandlowmap()` (two calls)

The argument has existed since valr 0.9.0, so this is compatible with current CRAN valr, and the existing fixture (`inst/extdata/finaltab.rds`) is reproduced without regeneration.

— Jay Hesselberth (valr maintainer)
